### PR TITLE
feat(kdrive): Add cursor pagination and folder-scoped search

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ MCP Server for the kDrive API.
     - Search in kDrive
     - Required inputs:
       - `query` (string): Search query
+    - Optional inputs:
+      - `directory_id` (number): Directory ID to scope the search to a specific folder subtree (default: root)
+      - `depth` (string): Search depth when `directory_id` is set — `unlimited` (recursive) or `child` (immediate children only)
     - Returns: List of files
 
 2. `kdrive_upload_file`

--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ MCP Server for the kDrive API.
     - Required inputs:
       - Optional: `file_id` (number): Folder ID (default: root=1)
       - Optional: `type` (string): Filter by `file` or `dir`
-    - Returns: Array of files and/or directories
+      - Optional: `cursor` (string): Pagination cursor returned by a previous call when `has_more` was `true`, used to fetch the next page of results
+    - Returns: Array of files and/or directories, plus `has_more` (boolean) and `cursor` (string) when more entries are available
 
 5. `kdrive_rename`
     - Rename a file or directory

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,12 +38,14 @@ const kDriveClient = new KdriveClient(token, drive_id);
 
 server.tool(
     "kdrive_search",
-    "Search for files in Infomanik kDrive",
+    "Search for files in Infomanik kDrive. Use directory_id to scope the search to a specific folder subtree, and depth to control whether the search is recursive (unlimited) or limited to immediate children (child).",
     {
-        query: z.string().describe("Search query")
+        query: z.string().describe("Search query"),
+        directory_id: z.number().optional().describe("Directory ID to scope the search to a specific folder subtree (default: root)"),
+        depth: z.enum(["child", "unlimited"]).optional().describe("Search depth: 'unlimited' for recursive search within the directory, 'child' for immediate children only. Use with directory_id."),
     },
-    async ({query}) => {
-        const response = await kDriveClient.search(query);
+    async ({query, directory_id, depth}) => {
+        const response = await kDriveClient.search(query, { directory_id, depth });
 
         return {
             content: [{type: "text", text: JSON.stringify(response)}],

--- a/src/index.ts
+++ b/src/index.ts
@@ -81,13 +81,14 @@ server.tool(
 
 server.tool(
     "kdrive_list",
-    "List files and directories in a folder",
+    "List files and directories in a folder. The response may include `has_more` and a `cursor` when more entries exist; pass that `cursor` to retrieve the next page.",
     {
         file_id: z.number().optional().describe("Directory ID (default is root = 1)"),
         type: z.enum(["file", "dir"]).optional().describe("Filter by type: file or dir"),
+        cursor: z.string().optional().describe("Pagination cursor returned by a previous call when `has_more` was true, used to fetch the next page of results"),
     },
-    async ({file_id, type}) => {
-        const response = await kDriveClient.listFiles(file_id ?? 1, type ? { type } : undefined);
+    async ({file_id, type, cursor}) => {
+        const response = await kDriveClient.listFiles(file_id ?? 1, { type, cursor });
         return {
             content: [{type: "text", text: JSON.stringify(response)}],
         };

--- a/src/kdrive-client.ts
+++ b/src/kdrive-client.ts
@@ -12,11 +12,17 @@ export class KdriveClient {
         };
     }
 
-    async search(query: string): Promise<any> {
+    async search(query: string, options?: { directory_id?: number; depth?: string }): Promise<any> {
         const params = new URLSearchParams({
             query,
             limit: "10"
         });
+        if (options?.directory_id !== undefined) {
+            params.set("directory_id", options.directory_id.toString());
+        }
+        if (options?.depth) {
+            params.set("depth", options.depth);
+        }
 
         const response = await fetch(
             `https://api.infomaniak.com/3/drive/${this.driveId}/files/search?${params}`,

--- a/src/kdrive-client.ts
+++ b/src/kdrive-client.ts
@@ -63,10 +63,13 @@ export class KdriveClient {
         return response.json();
     }
 
-    async listFiles(file_id = 1, filters?: { type?: string }): Promise<any> {
+    async listFiles(file_id = 1, filters?: { type?: string; cursor?: string }): Promise<any> {
         const params = new URLSearchParams();
         if (filters?.type) {
             params.set("type[]", filters.type);
+        }
+        if (filters?.cursor) {
+            params.set("cursor", filters.cursor);
         }
         const query = params.toString() ? `?${params}` : "";
 

--- a/tests/verify.mjs
+++ b/tests/verify.mjs
@@ -52,6 +52,56 @@ describe("KdriveClient.search", () => {
       restore();
     }
   });
+
+  test("scopes search to a directory when directory_id provided", async () => {
+    let capturedUrl = null;
+    const restore = mockFetch(async (url) => {
+      capturedUrl = url;
+      return { json: async () => ({ result: "success", data: [] }) };
+    });
+
+    try {
+      const client = new KdriveClient("mock-token", "123");
+      await client.search("test", { directory_id: 91535 });
+      assert.ok(capturedUrl.includes("directory_id=91535"), "URL contains directory_id");
+    } finally {
+      restore();
+    }
+  });
+
+  test("passes depth parameter when provided", async () => {
+    let capturedUrl = null;
+    const restore = mockFetch(async (url) => {
+      capturedUrl = url;
+      return { json: async () => ({ result: "success", data: [] }) };
+    });
+
+    try {
+      const client = new KdriveClient("mock-token", "123");
+      await client.search("test", { directory_id: 10, depth: "unlimited" });
+      assert.ok(capturedUrl.includes("directory_id=10"), "URL contains directory_id");
+      assert.ok(capturedUrl.includes("depth=unlimited"), "URL contains depth");
+    } finally {
+      restore();
+    }
+  });
+
+  test("does not include directory_id or depth when not provided", async () => {
+    let capturedUrl = null;
+    const restore = mockFetch(async (url) => {
+      capturedUrl = url;
+      return { json: async () => ({ result: "success", data: [] }) };
+    });
+
+    try {
+      const client = new KdriveClient("mock-token", "123");
+      await client.search("test");
+      assert.ok(!capturedUrl.includes("directory_id"), "URL does not contain directory_id");
+      assert.ok(!capturedUrl.includes("depth"), "URL does not contain depth");
+    } finally {
+      restore();
+    }
+  });
 });
 
 describe("KdriveClient.uploadFile", () => {

--- a/tests/verify.mjs
+++ b/tests/verify.mjs
@@ -143,6 +143,55 @@ describe("KdriveClient.listFiles", () => {
       restore();
     }
   });
+
+  test("lists files with cursor for pagination", async () => {
+    let capturedUrl = null;
+    const restore = mockFetch(async (url) => {
+      capturedUrl = url;
+      return { json: async () => ({ result: "success", data: [] }) };
+    });
+
+    try {
+      const client = new KdriveClient("mock-token", "123");
+      await client.listFiles(10, { cursor: "SGVsbG8gV29ybGQ" });
+      assert.ok(capturedUrl.includes("cursor=SGVsbG8gV29ybGQ"), "URL contains cursor");
+    } finally {
+      restore();
+    }
+  });
+
+  test("lists files with both type filter and cursor", async () => {
+    let capturedUrl = null;
+    const restore = mockFetch(async (url) => {
+      capturedUrl = url;
+      return { json: async () => ({ result: "success", data: [] }) };
+    });
+
+    try {
+      const client = new KdriveClient("mock-token", "123");
+      await client.listFiles(10, { type: "dir", cursor: "abc123" });
+      assert.ok(capturedUrl.includes("type%5B%5D=dir"), "URL contains type filter");
+      assert.ok(capturedUrl.includes("cursor=abc123"), "URL contains cursor");
+    } finally {
+      restore();
+    }
+  });
+
+  test("does not include cursor when not provided", async () => {
+    let capturedUrl = null;
+    const restore = mockFetch(async (url) => {
+      capturedUrl = url;
+      return { json: async () => ({ result: "success", data: [] }) };
+    });
+
+    try {
+      const client = new KdriveClient("mock-token", "123");
+      await client.listFiles(10);
+      assert.ok(!capturedUrl.includes("cursor"), "URL does not contain cursor");
+    } finally {
+      restore();
+    }
+  });
 });
 
 describe("KdriveClient.rename", () => {


### PR DESCRIPTION
## Context

`kdrive_list` could not fully list directories with more than 10 entries: the kDrive API returns `has_more` and a `cursor`, but the tool did not expose a way to fetch subsequent pages. `kdrive_search` had no way to restrict results to a specific folder subtree.

## Changes

### `kdrive_list` — cursor pagination (e4808d9)
- Added optional `cursor` parameter to the `kdrive_list` tool and the underlying `listFiles` client method
- The cursor is forwarded as the `cursor` query param to the kDrive API; when `has_more` is `true`, the response includes a `cursor` that can be passed back to fetch the next page

### `kdrive_search` — folder scoping (3e96a1e)
- Added optional `directory_id` and `depth` parameters to the `kdrive_search` tool and the `search` client method
- `directory_id` scopes the search to a specific folder subtree (default: root)
- `depth` controls recursion: `unlimited` (recursive) or `child` (immediate children only)
- `kdrive_recents` was **not** modified: the kDrive recents API endpoint does not accept any folder-scoping parameter

## Verification

- All 32 unit tests pass (3 new tests for cursor pagination, 3 new tests for search scoping)
- Tested live via MCP against a real kDrive:
  - Listed a 12-entry folder across 2 pages (10 + 2) using cursor pagination
  - Scoped search to a folder with `depth=child` (immediate children only) and `depth=unlimited` (recursive), confirming results were correctly filtered

Fixes #33